### PR TITLE
Dialog, Saving, and Form stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,8 @@ Once you have a running emulator you can build the project and run it on either 
 		* flutter doctor - Status check for all components related to the flutter project
 #### Troubleshooting    
  - **Android Studio** If you're having trouble building and running the application make sure to check Settings-> Languages & Frameworks -> Click on Flutter and Dart and make sure they have the proper SDK path. If these are blank and the plugin doesn't manage that for you. You must manually download the SDK's for both Flutter and Dart and put the explicit path in the settings.    
-    
+
+### Testing Application
+We have developed an automated group of tests that cover the entire workflow of the app. In order to run these tests you must first start an emulator. Then run the command `flutter driver --target=test_driver/blamo.dart` from the /BLAMO/blamo directory. Unfortunately, flutter driver currently provides no way to interact with system dialogues, so you must manually allow file access permission each time the test is run; this dialog will pop up during the test of the export page. Additionally, there is a 30 second window at the end of the export test where you can manually send the documents created by the test.
+
 #### Developed by James Trotter, Evan Amaya, Sean Spink, Alex Smith

--- a/blamo/lib/Boreholes/BoreholeList.dart
+++ b/blamo/lib/Boreholes/BoreholeList.dart
@@ -1,10 +1,9 @@
-import 'package:blamo/routeGenerator.dart';
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+import 'package:blamo/CustomActionBar.dart';
 import 'package:blamo/File_IO/FileHandler.dart';
 import 'package:blamo/SideMenu.dart';
-import 'package:blamo/CustomActionBar.dart';
-import 'package:flutter/services.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 
 //This class will be used to house all the data between each route
 class StateData {
@@ -32,25 +31,11 @@ class StateData {
   }
 }
 
- /* the idea behind the home page is a series of existing logs will appear in the white space, While the button in
-  * the bottom right will allow users to create a new log
-  * (the "second page" in this code is mostly a demonstration and can/should be removed in later implimentation) additionally,
-  * the drawer will provide easy familiar navigation between setting, export, etc. Activities/pages of the project
-  */
-//void main() => runApp(BLAMO());
-
-/* This builds the initial context and offloads
-*  route navigation to the routeGenerator class
+/* the idea behind the home page is a series of existing logs will appear in the white space, While the button in
+* the bottom right will allow users to create a new log
+* (the "second page" in this code is mostly a demonstration and can/should be removed in later implimentation) additionally,
+* the drawer will provide easy familiar navigation between setting, export, etc. Activities/pages of the project
 */
-/*class BLAMO extends StatelessWidget {
-  @override
-  Widget build(BuildContext context){
-    return MaterialApp(
-      initialRoute: '/',
-      onGenerateRoute: RouteGenerator.generateRoute,
-    );
-  }
-}*/
 
 /* All pages must take in state data. The Stateful widget sole job
 *  is to pass the StateData object to the constructor during the
@@ -59,8 +44,6 @@ class StateData {
 * */
 class BoreholePage extends StatefulWidget {
   final StateData pass;
-  //--Toremove
-  //final PersistentStorage storage = PersistentStorage();
 
   BoreholePage(this.pass, {Key key}) : super(key:key);
 
@@ -77,8 +60,6 @@ class _BoreholePageState extends State<BoreholePage> {
   StateData currentState;
   _BoreholePageState(this.currentState);
 
-  TextEditingController _textFieldController = TextEditingController();
-
   @override
   void initState() {
     super.initState();
@@ -86,9 +67,6 @@ class _BoreholePageState extends State<BoreholePage> {
       setState(() {
         currentState.list = recieved.list;
         currentState.currentRoute = '/BoreholeList';
-//
-        //TODO: REMOVE THIS LINE WHEN DONE WITH NEW MAIN
-        //currentState.currentProject = 'Salem Bridge';
 
         currentState.dirty = 1;
       });
@@ -152,12 +130,12 @@ class _BoreholePageState extends State<BoreholePage> {
   }
 
   //Creates a new document manifest
-  void createNewDocument(String docName) async{
+  Future<void> createNewDocument(String docName) async{
     await currentState.storage.overWriteDocument(docName, "$docName\n0\n0");
   }
 
   //Updates the currentState object to reflect the manifest document
-  void updateStateData() async{
+  Future<void> updateStateData() async{
     await currentState.storage.setStateData(currentState).then((StateData recieved) {
       currentState.list = recieved.list;
       currentState.dirty = 0;
@@ -180,7 +158,6 @@ class _BoreholePageState extends State<BoreholePage> {
       "/Document",
       arguments: currentState,
     );
-    //currentState.currentDocument = "";
   }
 
   void _showToast(String toShow, MaterialColor color){
@@ -203,19 +180,29 @@ class _BoreholePageState extends State<BoreholePage> {
         context: context,
         builder: (context) =>
             AlertDialog(
-              title: Text("Are you sure you want to delete ${currentState
-                  .currentDocument}?"),
+              title:
+                Text("Are you sure you want to delete ${currentState
+                  .currentDocument}?",
+                style: TextStyle(
+                    fontSize: 20,
+                ),),
               actions: <Widget>[
                 new FlatButton(
-                    child: Text("DELETE"),
-                    textColor: Colors.red,
+                    child: Text("Delete",
+                      style: TextStyle(
+                        fontSize: 20,
+                        color: Colors.red,
+                      ),),
                     onPressed: () {
                       Navigator.pop(context, "DELETE");
                     },
                     key: Key('boreholeDelete'),
                 ),
                 new FlatButton(
-                  child: Text("CANCEL"),
+                  child: Text("Cancel",
+                    style: TextStyle(
+                      fontSize: 20,
+                    ),),
                   onPressed: () {
                     Navigator.pop(context, "CANCEL");
                   },
@@ -270,7 +257,7 @@ class _BoreholePageState extends State<BoreholePage> {
        newestDoc = 'BH_' + nextHoleNum.toString();
      }
      await currentState.storage.overWriteManifest(toWrite);
-     await currentState.storage.overWriteLogInfo('BH_' + nextHoleNum.toString(), "{project:null,number:null,client:null,highway:null,county:null,projection:NAD 1983 2011 Oregon Statewide Lambert Ft Intl,north:null,east:null,lat:null,long:null,location:null,elevationDatum:null,tubeHeight:null,boreholeID:null,startDate:null,endDate:null,surfaceElevation:null,contractor:null,equipment:null,method:null,loggedBy:null,checkedBy:null}");
+     await currentState.storage.overWriteLogInfo('BH_' + nextHoleNum.toString(), "{project:"+currentState.currentProject+",number:\""+nextHoleNum.toString()+"\",client:null,highway:null,county:null,projection:NAD 1983 2011 Oregon Statewide Lambert Ft Intl,north:null,east:null,lat:null,long:null,location:null,elevationDatum:null,tubeHeight:null,boreholeID:null,startDate:null,endDate:null,surfaceElevation:null,contractor:null,equipment:null,method:null,loggedBy:null,checkedBy:null}");
      await updateStateDataCreateDoc(newestDoc);
      //setState(() {});
 

--- a/blamo/lib/LogInfo/loginfo.dart
+++ b/blamo/lib/LogInfo/loginfo.dart
@@ -75,27 +75,27 @@ class _LogInfoPageState extends State<LogInfoPage> {
     bool userInput = await showDialog(
         context: context,
         builder: (context) => AlertDialog(
-            title: Text("Are you sure you want to leave this page? \n\n All unsaved data will be discarded."),
+            title: Text("Are you sure you want to leave this page?\n\nAll unsaved data will be discarded."),
             actions: <Widget>[
-              FlatButton(
-                child: Text(
-                  "No",
-                  style: TextStyle(
-                      fontSize: 25,
-                  ),
-                ),
-                onPressed: () => Navigator.pop(context,false),
-              ),
               FlatButton(
                 child: Text(
                   "Yes",
                   style: TextStyle(
-                      fontSize: 25,
+                      fontSize: 20,
                       color: Colors.red
                   ),
                 ),
                 onPressed: () => Navigator.pop(context,true),
-              )
+              ),
+              FlatButton(
+                child: Text(
+                  "No",
+                  style: TextStyle(
+                    fontSize: 20,
+                  ),
+                ),
+                onPressed: () => Navigator.pop(context,false),
+              ),
             ]
         )
     );

--- a/blamo/lib/SideMenu.dart
+++ b/blamo/lib/SideMenu.dart
@@ -1,5 +1,6 @@
-import 'package:blamo/Boreholes/BoreholeList.dart';
 import 'package:flutter/material.dart';
+
+import 'package:blamo/Boreholes/BoreholeList.dart';
 
 //Side menu class that creates the side menu state
 class SideMenu extends StatefulWidget {
@@ -78,7 +79,48 @@ class _SideMenuState extends State<SideMenu> {
                       color: Colors.blue
                   ),
                   onTap: () {
-                    if (currentState.currentRoute != '/') {
+                    if (currentState.currentRoute == '/LogInfoPage') {
+                      showDialog(
+                        context: context,
+                        builder: (context) =>
+                        AlertDialog(
+                          title: Text(
+                              "Are you sure you want to leave this page?\n\nAll unsaved data will be discarded.",
+                            style: TextStyle(
+                              fontSize: 20,
+                            ),),
+                          actions: <Widget>[
+                            FlatButton(
+                              child: Text(
+                                "Yes",
+                                style: TextStyle(
+                                  fontSize: 20,
+                                  color: Colors.red,
+                                ),
+                              ),
+                              onPressed: () {
+                                currentState.currentRoute = '/';
+                                currentState.currentDocument = "";
+                                Navigator.pushReplacementNamed(
+                                  context,
+                                  "/",
+                                  arguments: currentState,
+                                );
+                              }
+                            ),
+                            FlatButton(
+                              child: Text(
+                                "No",
+                                style: TextStyle(
+                                  fontSize: 20,
+                                ),
+                              ),
+                              onPressed: () => Navigator.pop(context, false),
+                            ),
+                          ]
+                        )
+                      );
+                    } else if (currentState.currentRoute != '/') {
                       currentState.currentRoute = '/';
                       currentState.currentDocument = "";
                       Navigator.pushReplacementNamed(
@@ -99,7 +141,47 @@ class _SideMenuState extends State<SideMenu> {
                       color: Colors.blue
                   ),
                   onTap: () {
-                    if (currentState.currentRoute != '/ExportPage') {
+                    if (currentState.currentRoute == '/LogInfoPage') {
+                      showDialog(
+                        context: context,
+                        builder: (context) =>
+                        AlertDialog(
+                          title: Text(
+                              "Are you sure you want to leave this page?\n\nAll unsaved data will be discarded.",
+                            style: TextStyle(
+                              fontSize: 20,
+                            ),),
+                          actions: <Widget>[
+                            FlatButton(
+                              child: Text(
+                                "Yes",
+                                style: TextStyle(
+                                  fontSize: 20,
+                                  color: Colors.red,
+                                ),
+                              ),
+                              onPressed: () {
+                                currentState.currentRoute = '/ExportPage';
+                                Navigator.pushReplacementNamed(
+                                  context,
+                                  "/ExportPage",
+                                  arguments: currentState,
+                                );
+                              }
+                            ),
+                            FlatButton(
+                              child: Text(
+                                "No",
+                                style: TextStyle(
+                                  fontSize: 20,
+                                ),
+                              ),
+                              onPressed: () => Navigator.pop(context, false),
+                            ),
+                          ]
+                        )
+                      );
+                    } else if (currentState.currentRoute != '/ExportPage') {
                       currentState.currentRoute = '/ExportPage';
                       Navigator.pushReplacementNamed(
                         context,
@@ -120,7 +202,48 @@ class _SideMenuState extends State<SideMenu> {
                       color: Colors.blue
                   ),
                   onTap: () {
-                    if (currentState.currentRoute != '/BoreholeList') {
+                    if (currentState.currentRoute == '/LogInfoPage') {
+                      showDialog(
+                          context: context,
+                          builder: (context) =>
+                              AlertDialog(
+                                  title: Text(
+                                      "Are you sure you want to leave this page?\n\nAll unsaved data will be discarded.",
+                                    style: TextStyle(
+                                      fontSize: 20,
+                                    ),),
+                                  actions: <Widget>[
+                                    FlatButton(
+                                      child: Text(
+                                        "Yes",
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                          color: Colors.red,
+                                        ),
+                                      ),
+                                      onPressed: () {
+                                        currentState.currentRoute = '/BoreholeList';
+                                        currentState.currentDocument="";
+                                        Navigator.pushReplacementNamed(
+                                          context,
+                                          "/BoreholeList",
+                                          arguments: currentState,
+                                        );
+                                      }
+                                    ),
+                                    FlatButton(
+                                      child: Text(
+                                        "No",
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                        ),
+                                      ),
+                                      onPressed: () => Navigator.pop(context, false),
+                                    ),
+                                  ]
+                              )
+                      );
+                    } else if (currentState.currentRoute != '/BoreholeList') {
                       currentState.currentRoute = '/BoreholeList';
                       currentState.currentDocument="";
                       Navigator.pushReplacementNamed(
@@ -142,7 +265,47 @@ class _SideMenuState extends State<SideMenu> {
                       color: Colors.blue
                   ),
                   onTap: () {
-                    if (currentState.currentRoute != '/Document') {
+                    if (currentState.currentRoute == '/LogInfoPage') {
+                      showDialog(
+                          context: context,
+                          builder: (context) =>
+                              AlertDialog(
+                                  title: Text(
+                                      "Are you sure you want to leave this page?\n\nAll unsaved data will be discarded.",
+                                    style: TextStyle(
+                                      fontSize: 20,
+                                    ),),
+                                  actions: <Widget>[
+                                    FlatButton(
+                                      child: Text(
+                                        "Yes",
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                          color: Colors.red,
+                                        ),
+                                      ),
+                                      onPressed: () {
+                                        currentState.currentRoute = '/Document';
+                                        Navigator.pushReplacementNamed(
+                                          context,
+                                          "/Document",
+                                          arguments: currentState,
+                                        );
+                                      }
+                                    ),
+                                    FlatButton(
+                                      child: Text(
+                                        "No",
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                        ),
+                                      ),
+                                      onPressed: () => Navigator.pop(context, false),
+                                    ),
+                                  ]
+                              )
+                      );
+                    } else if (currentState.currentRoute != '/Document') {
                       currentState.currentRoute = '/Document';
                       Navigator.pushReplacementNamed(
                         context,
@@ -183,7 +346,46 @@ class _SideMenuState extends State<SideMenu> {
                       color: Colors.blue
                   ),
                   onTap: () {
-                    if (currentState.currentRoute != '/UnitsPage') {
+                    if (currentState.currentRoute == '/LogInfoPage') {
+                      showDialog(
+                          context: context,
+                          builder: (context) =>
+                              AlertDialog(
+                                  title: Text(
+                                      "Are you sure you want to leave this page?\n\nAll unsaved data will be discarded.",
+                                    style: TextStyle(
+                                      fontSize: 20,
+                                    ),),
+                                  actions: <Widget>[
+                                    FlatButton(
+                                      child: Text(
+                                        "Yes",
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                          color: Colors.red,
+                                        ),
+                                      ),
+                                      onPressed: () {
+                                        Navigator.pushReplacementNamed(
+                                          context,
+                                          "/UnitsPage",
+                                          arguments: currentState,
+                                        );
+                                      }
+                                    ),
+                                    FlatButton(
+                                      child: Text(
+                                        "No",
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                        ),
+                                      ),
+                                      onPressed: () => Navigator.pop(context, false),
+                                    ),
+                                  ]
+                              )
+                      );
+                    } else if (currentState.currentRoute != '/UnitsPage') {
                       Navigator.pushReplacementNamed(
                         context,
                         "/UnitsPage",
@@ -203,7 +405,46 @@ class _SideMenuState extends State<SideMenu> {
                       color: Colors.blue
                   ),
                   onTap: () {
-                    if (currentState.currentRoute != '/TestsPage') {
+                    if (currentState.currentRoute == '/LogInfoPage') {
+                      showDialog(
+                          context: context,
+                          builder: (context) =>
+                              AlertDialog(
+                                  title: Text(
+                                      "Are you sure you want to leave this page?\n\nAll unsaved data will be discarded.",
+                                    style: TextStyle(
+                                      fontSize: 20,
+                                    ),),
+                                  actions: <Widget>[
+                                    FlatButton(
+                                      child: Text(
+                                        "Yes",
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                          color: Colors.red,
+                                        ),
+                                      ),
+                                      onPressed: () {
+                                        Navigator.pushReplacementNamed(
+                                          context,
+                                          "/TestsPage",
+                                          arguments: currentState,
+                                        );
+                                      }
+                                    ),
+                                    FlatButton(
+                                      child: Text(
+                                        "No",
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                        ),
+                                      ),
+                                      onPressed: () => Navigator.pop(context, false),
+                                    ),
+                                  ]
+                              )
+                      );
+                    } else if (currentState.currentRoute != '/TestsPage') {
                       Navigator.pushReplacementNamed(
                         context,
                         "/TestsPage",

--- a/blamo/lib/Test/test.dart
+++ b/blamo/lib/Test/test.dart
@@ -85,27 +85,30 @@ class _TestPageState extends State<TestPage> {
       return showDialog(
           context: context,
           builder: (context) => AlertDialog(
-              title: Text("Are you sure you want to leave this page? \n\n All unsaved data will be discarded."),
+              title: Text("Are you sure you want to leave this page?\n\nAll unsaved data will be discarded.",
+                style: TextStyle(
+                  fontSize: 20,
+                ),),
               actions: <Widget>[
-                FlatButton(
-                  child: Text(
-                    "No",
-                    style: TextStyle(
-                      fontSize: 25,
-                    ),
-                  ),
-                  onPressed: () => Navigator.pop(context,false),
-                ),
                 FlatButton(
                   child: Text(
                     "Yes",
                     style: TextStyle(
-                        fontSize: 25,
+                        fontSize: 20,
                         color: Colors.red
                     ),
                   ),
                   onPressed: () => Navigator.pop(context,true),
-                )
+                ),
+                FlatButton(
+                  child: Text(
+                    "No",
+                    style: TextStyle(
+                      fontSize: 20,
+                    ),
+                  ),
+                  onPressed: () => Navigator.pop(context,false),
+                ),
               ]
           )
       );
@@ -113,27 +116,30 @@ class _TestPageState extends State<TestPage> {
       return showDialog(
           context: context,
           builder: (context) => AlertDialog(
-              title: Text("There are fields with invalid inputs\n\nTest will be deleted"),
+              title: Text("There are fields with invalid inputs\n\nTest will be deleted",
+                style: TextStyle(
+                  fontSize: 20,
+                ),),
               actions: <Widget>[
-                FlatButton(
-                  child: Text(
-                    "Edit",
-                    style: TextStyle(
-                      fontSize: 25,
-                    ),
-                  ),
-                  onPressed: () => Navigator.pop(context,false),
-                ),
                 FlatButton(
                   child: Text(
                     "Delete",
                     style: TextStyle(
-                        fontSize: 25,
+                        fontSize: 20,
                         color: Colors.red
                     ),
                   ),
                   onPressed: () => deleteBadTest(),
-                )
+                ),
+                FlatButton(
+                  child: Text(
+                    "Edit",
+                    style: TextStyle(
+                      fontSize: 20,
+                    ),
+                  ),
+                  onPressed: () => Navigator.pop(context,false),
+                ),
               ]
           )
       );
@@ -491,9 +497,7 @@ class _TestPageState extends State<TestPage> {
               bool noOverlap = await checkTestDepthOverlap();
               if(noOverlap) {
                 await saveTestObject();
-                currentState.currentRoute = '/TestsPage';
                 _showToast("Success", Colors.green);
-                Navigator.pop(context, "Success");
               } else {
                 _showToast("Test overlaps another Test", Colors.red);
               }

--- a/blamo/lib/Test/tests.dart
+++ b/blamo/lib/Test/tests.dart
@@ -204,17 +204,26 @@ class _TestsPageState extends State<TestsPage> {
     result = await showDialog(
         context: context,
         builder: (context) => AlertDialog(
-          title: Text("Are you sure you want to delete this test?"),
+          title: Text("Are you sure you want to delete this test?",
+            style: TextStyle(
+              fontSize: 20,
+            ),),
           actions: <Widget>[
             new FlatButton(
-                child: Text("DELETE"),
-                textColor: Colors.red,
+                child: Text("Delete",
+                  style: TextStyle(
+                    fontSize: 20,
+                    color: Colors.red,
+                  ),),
                 key: Key('deleteTest'),
                 onPressed: () {
                   Navigator.pop(context, "DELETE");
                 }),
             new FlatButton(
-              child: Text("CANCEL"),
+              child: Text("Cancel",
+                style: TextStyle(
+                  fontSize: 20,
+                ),),
               onPressed: (){
                 Navigator.pop(context, "CANCEL");
               },

--- a/blamo/lib/Unit/unit.dart
+++ b/blamo/lib/Unit/unit.dart
@@ -91,27 +91,30 @@ class _UnitPageState extends State<UnitPage> {
           builder: (context) =>
               AlertDialog(
                   title: Text(
-                      "Are you sure you want to leave this page? \n\n All unsaved data will be discarded."),
+                      "Are you sure you want to leave this page?\n\nAll unsaved data will be discarded.",
+                    style: TextStyle(
+                      fontSize: 20,
+                    ),),
                   actions: <Widget>[
-                    FlatButton(
-                      child: Text(
-                        "No",
-                        style: TextStyle(
-                          fontSize: 25,
-                        ),
-                      ),
-                      onPressed: () => Navigator.pop(context, false),
-                    ),
                     FlatButton(
                       child: Text(
                         "Yes",
                         style: TextStyle(
-                            fontSize: 25,
+                            fontSize: 20,
                             color: Colors.red
                         ),
                       ),
                       onPressed: () => Navigator.pop(context, true),
-                    )
+                    ),
+                    FlatButton(
+                      child: Text(
+                        "No",
+                        style: TextStyle(
+                          fontSize: 20,
+                        ),
+                      ),
+                      onPressed: () => Navigator.pop(context, false),
+                    ),
                   ]
               )
       );
@@ -121,27 +124,30 @@ class _UnitPageState extends State<UnitPage> {
           builder: (context) =>
               AlertDialog(
                   title: Text(
-                      "There are fields with invalid inputs\n\nUnit will be deleted"),
+                      "There are fields with invalid inputs\n\nUnit will be deleted",
+                    style: TextStyle(
+                      fontSize: 20,
+                    ),),
                   actions: <Widget>[
-                    FlatButton(
-                      child: Text(
-                        "Edit",
-                        style: TextStyle(
-                          fontSize: 25,
-                        ),
-                      ),
-                      onPressed: () => Navigator.pop(context, false),
-                    ),
                     FlatButton(
                       child: Text(
                         "Delete",
                         style: TextStyle(
-                            fontSize: 25,
+                            fontSize: 20,
                             color: Colors.red
                         ),
                       ),
                       onPressed: () => deleteBadUnit(),
-                    )
+                    ),
+                    FlatButton(
+                      child: Text(
+                        "Edit",
+                        style: TextStyle(
+                          fontSize: 20,
+                        ),
+                      ),
+                      onPressed: () => Navigator.pop(context, false),
+                    ),
                   ]
               )
       );
@@ -397,9 +403,7 @@ class _UnitPageState extends State<UnitPage> {
               bool noOverlap = await checkUnitDepthOverlap();
               if (noOverlap) {
                 await saveObject();
-                currentState.currentRoute = '/UnitsPage';
                 _showToast("Success", Colors.green);
-                Navigator.pop(context, "Success");
               } else {
                 _showToast("Unit overlaps another Unit", Colors.red);
               }

--- a/blamo/lib/Unit/units.dart
+++ b/blamo/lib/Unit/units.dart
@@ -199,17 +199,26 @@ class _UnitsPageState extends State<UnitsPage> {
     result = await showDialog(
         context: context,
         builder: (context) => AlertDialog(
-          title: Text("Are you sure you want to delete this unit?"),
+          title: Text("Are you sure you want to delete this unit?",
+            style: TextStyle(
+              fontSize: 20,
+            ),),
           actions: <Widget>[
             new FlatButton(
-                child: Text("DELETE"),
+                child: Text("Delete",
+                  style: TextStyle(
+                    fontSize: 20,
+                    color: Colors.red,
+                  ),),
                 key: Key('deleteUnit'),
-                textColor: Colors.red,
                 onPressed: () {
                   Navigator.pop(context, "DELETE");
                 }),
             new FlatButton(
-              child: Text("CANCEL"),
+              child: Text("Cancel",
+                style: TextStyle(
+                  fontSize: 20,
+                ),),
               onPressed: (){
                 Navigator.pop(context, "CANCEL");
               },

--- a/blamo/lib/main.dart
+++ b/blamo/lib/main.dart
@@ -1,10 +1,10 @@
-
-import 'package:blamo/Boreholes/BoreholeList.dart';
-import 'package:blamo/routeGenerator.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+
+import 'package:blamo/Boreholes/BoreholeList.dart';
+import 'package:blamo/routeGenerator.dart';
 
 void main() => runApp(BLAMO());
 
@@ -184,17 +184,26 @@ class _HomePageState extends State<HomePage> {
         context: context,
         builder: (context) =>
             AlertDialog(
-              title: Text("Are you sure you want to delete ${projectName}?"),
+              title: Text("Are you sure you want to delete $projectName?",
+                style: TextStyle(
+                  fontSize: 20,
+                ),),
               actions: <Widget>[
                 new FlatButton(
-                    child: Text("DELETE"),
+                    child: Text("Delete",
+                      style: TextStyle(
+                        fontSize: 20,
+                        color: Colors.red,
+                      ),),
                     key: Key('projectDelete'),
-                    textColor: Colors.red,
                     onPressed: () {
                       Navigator.pop(context, "DELETE");
                     }),
                 new FlatButton(
-                  child: Text("CANCEL"),
+                  child: Text("Cancel",
+                    style: TextStyle(
+                      fontSize: 20,
+                    ),),
                   onPressed: () {
                     Navigator.pop(context, "CANCEL");
                   },
@@ -231,7 +240,10 @@ class _HomePageState extends State<HomePage> {
         showDialog(
             context: context,
           builder:(context) => AlertDialog(
-            title: Text('Enter Project Name'),
+            title: Text('Enter Project Name',
+              style: TextStyle(
+                fontSize: 20,
+              ),),
             content: TextField(
               maxLength: 20,
               controller: _textFieldController,
@@ -241,14 +253,20 @@ class _HomePageState extends State<HomePage> {
             ),
             actions: <Widget>[
               new FlatButton(
-                child: new Text('CANCEL'),
-                textColor: Colors.red,
+                child: new Text('Cancel',
+                  style: TextStyle(
+                    fontSize: 20,
+                    color: Colors.red,
+                  ),),
                 onPressed: () {
                   Navigator.of(context).pop();
                 },
               ),
               new FlatButton(
-                child: new Text('Accept'),
+                child: new Text('Accept',
+                  style: TextStyle(
+                    fontSize: 20,
+                  ),),
                 key: Key('projectAccept'),
                 onPressed: () async {
                   if(_textFieldController.text.isNotEmpty && !currentState.list.contains(_textFieldController.text.toString())) {
@@ -276,27 +294,30 @@ class _HomePageState extends State<HomePage> {
     return showDialog(
         context: context,
         builder: (context) => AlertDialog(
-            title: Text("Do you want to exit the BLAMO application?"),
+            title: Text("Do you want to exit the BLAMO application?",
+              style: TextStyle(
+                fontSize: 20,
+              ),),
             actions: <Widget>[
-              FlatButton(
-                child: Text(
-                  "No",
-                  style: TextStyle(
-                    fontSize: 25,
-                  ),
-                ),
-                onPressed: () => Navigator.pop(context,false),
-              ),
               FlatButton(
                 child: Text(
                   "Yes",
                   style: TextStyle(
-                      fontSize: 25,
+                      fontSize: 20,
                       color: Colors.red
                   ),
                 ),
                 onPressed: () => Navigator.pop(context,true),
-              )
+              ),
+              FlatButton(
+                child: Text(
+                  "No",
+                  style: TextStyle(
+                    fontSize: 20,
+                  ),
+                ),
+                onPressed: () => Navigator.pop(context,false),
+              ),
             ]
         )
     );

--- a/blamo/test_driver/blamo_test.dart
+++ b/blamo/test_driver/blamo_test.dart
@@ -115,14 +115,13 @@ void main() {
       final logInfoNavFinder = find.byValueKey('loginfoNav');
       await driver.tap(logInfoNavFinder);
       await takeScreenshot(driver, 'screenshots/test3_screenshot1.png');
-      var fieldKeys = ['project', 'number', 'client', 'highway', 'county',
-        'north', 'east', 'lat', 'long', 'location', 'elevationDatum',
-        'tubeHeight', 'boreholeID', 'surfaceElevation', 'contractor',
-        'equipment', 'method', 'loggedBy', 'checkedBy'];
-      var fieldInputs = ['project', '1001', 'client', 'highway', 'county',
-        '10000.00', '9999.99', '-122.00', '45.00', 'location', 'elevationDatum',
-        '100', 'boreholeID', '12345.5', 'contractor', 'equipment', 'method',
-        'loggedBy', 'checkedBy'];
+      var fieldKeys = ['client', 'highway', 'county', 'north', 'east', 'lat',
+        'long', 'location', 'elevationDatum', 'tubeHeight', 'boreholeID',
+        'surfaceElevation', 'contractor', 'equipment', 'method', 'loggedBy',
+        'checkedBy'];
+      var fieldInputs = ['client', 'highway', 'county', '10000.00', '9999.99',
+        '-122.00', '45.00', 'location', 'elevationDatum', '100', 'boreholeID',
+        '12345.5', 'contractor', 'equipment', 'method', 'loggedBy', 'checkedBy'];
       // Go through all text fields
       for(int i = 0; i < fieldKeys.length; i++) {
         SerializableFinder formFieldFinder = find.byValueKey(fieldKeys[i] + 'Field');
@@ -162,6 +161,8 @@ void main() {
       await driver.tap(drawerOpenFinder);
       final overviewNavFinder = find.byValueKey('overviewNav');
       await driver.tap(overviewNavFinder);
+      final dialogFinder = find.text('Yes');
+      await driver.tap(dialogFinder);
     }, timeout: Timeout(Duration(minutes: 1)));
 
     // This test creates 10 units and enter info for all of them then deletes
@@ -195,6 +196,10 @@ void main() {
 
         SerializableFinder saveUnitFinder = find.byValueKey('saveUnit');
         await driver.tap(saveUnitFinder);
+        SerializableFinder backOutFinder = find.pageBack();
+        await driver.tap(backOutFinder);
+        SerializableFinder dialogFinder = find.text('Yes');
+        await driver.tap(dialogFinder);
       }
       await takeScreenshot(driver, 'screenshots/test4_screenshot2.png');
 
@@ -246,6 +251,10 @@ void main() {
 
         SerializableFinder saveTestFinder = find.byValueKey('saveTest');
         await driver.tap(saveTestFinder);
+        SerializableFinder backOutFinder = find.pageBack();
+        await driver.tap(backOutFinder);
+        SerializableFinder dialogFinder = find.text('Yes');
+        await driver.tap(dialogFinder);
       }
       await takeScreenshot(driver, 'screenshots/test5_screenshot2.png');
 


### PR DESCRIPTION
Project and number fields in Log Info now auto fill.
Saving unit/test now stays on unit/test form page
Navigating away from log info via the side menu now displays a dialog
All dialogues now have consistent styling.
List of dialogues:
- home page back
- project delete
- project creation
- borehole delete
- loginfo side menu navigation
- loginfo back
- bad unit delete
- unit back
- units delete
- bad test delete
- test back
- tests delete

Updated test driver to work with changes